### PR TITLE
Use millisecond granularity in event timestamps (close #7)

### DIFF
--- a/src/source/Snowplow/Internal/Event.bs
+++ b/src/source/Snowplow/Internal/Event.bs
@@ -11,6 +11,7 @@
  
 import "pkg:/source/Snowplow/Internal/Parameters.bs"
 import "pkg:/source/Snowplow/Internal/EventContext.bs"
+import "pkg:/source/Snowplow/Internal/Helpers.bs"
 
 namespace Snowplow.Internal
     class Event
@@ -30,7 +31,8 @@ namespace Snowplow.Internal
         context as object
 
         sub new(data as object)
-            m.deviceTimestamp = m.currentTimestamp()
+            helpers = new Snowplow.Internal.Helpers()
+            m.deviceTimestamp = helpers.currentTimestamp()
             deviceInfo = CreateObject("roDeviceInfo")
             m.eventId = deviceInfo.GetRandomUUID()
 
@@ -50,6 +52,7 @@ namespace Snowplow.Internal
             payload = {}
             params = new Snowplow.Internal.Parameters()
             constants = new Snowplow.Internal.TrackerConstants()
+            helpers = new Snowplow.Internal.Helpers()
 
             ' required properties
             payload[params.EVENT] = m.getEventName()
@@ -57,7 +60,7 @@ namespace Snowplow.Internal
             payload[params.TRACKER_VERSION] = m.trackerVersion
             payload[params.PLATFORM] = m.platform
             payload[params.DEVICE_TIMESTAMP] = m.deviceTimestamp
-            payload[params.SENT_TIMESTAMP] = m.currentTimestamp()
+            payload[params.SENT_TIMESTAMP] = helpers.currentTimestamp()
             payload[params.NAMESPACE_] = m.trackerNamespace
 
             ' optional properties
@@ -96,10 +99,6 @@ namespace Snowplow.Internal
             data[params.DATA] = [m.preparePayloadToSend()]
             data[params.SCHEMA] = constants.SCHEMA_PAYLOAD_DATA
             return data
-        end function
-
-        private function currentTimestamp() as string
-            return CreateObject("roDateTime").AsSeconds().ToStr() + "000"
         end function
     end class
 end namespace

--- a/src/source/Snowplow/Internal/Helpers.bs
+++ b/src/source/Snowplow/Internal/Helpers.bs
@@ -1,0 +1,17 @@
+namespace Snowplow.Internal
+    class Helpers
+        function currentTimestamp() as string
+            dt = CreateObject("roDateTime")
+            ms = dt.GetMilliseconds()
+            return dt.AsSeconds().ToStr() + m.padWithZeros(ms, 3)
+        end function
+
+        private function padWithZeros(value as dynamic, padLength = 2 as integer) as string
+            valueStr = value.ToStr()
+            while valueStr.len() < padLength
+                valueStr = "0" + valueStr
+            end while
+            return valueStr
+        end function
+    end class
+end namespace

--- a/tests/source/Unit/Event.spec.bs
+++ b/tests/source/Unit/Event.spec.bs
@@ -1,4 +1,5 @@
 import "pkg:/source/Snowplow/Internal/Event.bs"
+import "pkg:/source/Snowplow/Internal/Helpers.bs"
 
 namespace tests
 
@@ -88,7 +89,8 @@ namespace tests
         '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
         private function getTimestamp() as string
-            return CreateObject("roDateTime").AsSeconds().ToStr() + "000"
+            helpers = new Snowplow.Internal.Helpers()
+            return helpers.currentTimestamp()
         end function
     end class
 end namespace

--- a/tests/source/Unit/Helpers.spec.bs
+++ b/tests/source/Unit/Helpers.spec.bs
@@ -1,0 +1,34 @@
+import "pkg:/source/Snowplow/Internal/Helpers.bs"
+
+namespace tests
+
+    @suite("Helpers tests")
+    class HelpersTests extends Rooibos.BaseTestSuite
+
+        '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+        @describe("currentTimestamp")
+        '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+        @beforeEach
+        sub beforeEachCreateHelpers()
+            m.helpers = new Snowplow.Internal.Helpers()
+        end sub
+
+        @it("returns timestamps larger than current unix seconds")
+        function currentTimestampLargerThanUnixSeconds()
+            tm1 = CreateObject("roDateTime").AsSeconds().ToStr() + "000"
+            tm2 = m.helpers.currentTimestamp()
+
+            m.assertTrue(tm1 < tm2)
+        end function
+
+        @it("returns timestamps that increase over time")
+        function currentTimestampIncreases()
+            tm1 = m.helpers.currentTimestamp()
+            sleep(100)
+            tm2 = m.helpers.currentTimestamp()
+
+            m.assertTrue(tm1 < tm2)
+        end function
+    end class
+end namespace


### PR DESCRIPTION
Add milliseconds to automatically generated event timestamps. In the previous release, only seconds were used in event timestamps as the official SDK only returned seconds when asked for a unix timestamp. I implemented a custom function for generating timestamps which also appends the milliseconds.