### PR TITLE
v0.3 bug fixes

### DIFF
--- a/src/components/Snowplow/Snowplow.bs
+++ b/src/components/Snowplow/Snowplow.bs
@@ -84,6 +84,16 @@ sub trackMedia(data as object)
     end for
 end sub
 
+' Tracks a custom media event with associated media player entities
+' @param {assocarray} data Custom media event
+sub trackMediaEvent(data as object)
+    data = data.getData()
+    if m.trackerNamespaces.count() = 0 then m.log.error("No tracker initialized")
+    for each trackerNamespace in m.trackerNamespaces
+        m.top[trackerNamespace].trackMediaEvent = data
+    end for
+end sub
+
 ' Stop media tracking and unobserve events on all initialized trackers
 ' @param {assocarray} data Media properties
 sub stopTrackingMedia(data)

--- a/src/components/Snowplow/SnowplowTracker.bs
+++ b/src/components/Snowplow/SnowplowTracker.bs
@@ -97,6 +97,7 @@ sub initializeTracker(data)
         connection = new Snowplow.Internal.NetworkConnection()
         emitter = new Snowplow.Internal.Emitter(configuration, connection)
         m.tracker = new Snowplow.Internal.Tracker(configuration, emitter)
+        if configuration.trackInstall then m.tracker.trackApplicationInstall()
     else
         m.tracker.updateConfiguration(configuration)
     end if

--- a/src/source/Snowplow/Internal/ClientSessionContextBuilder.bs
+++ b/src/source/Snowplow/Internal/ClientSessionContextBuilder.bs
@@ -30,6 +30,7 @@ namespace Snowplow.Internal
         sessionIndex as integer
         eventIndex as integer
         previousSessionId as string
+        newInstall = false
 
         sub new(configuration as object)
             m.tracker = configuration.trackerNamespace
@@ -43,7 +44,10 @@ namespace Snowplow.Internal
 
             ' restore previous state
             m.userId = m.registry.Read(`${m.tracker}:userId`)
-            if m.userId = "" then m.userId = m.deviceInfo.GetRandomUUID()
+            if m.userId = ""
+                m.userId = m.deviceInfo.GetRandomUUID()
+                m.newInstall = true
+            end if
 
             storedSessionId = m.registry.Read(`${m.tracker}:sessionId`)
             m.previousSessionId = storedSessionId <> "" ? storedSessionId : invalid
@@ -107,6 +111,10 @@ namespace Snowplow.Internal
             if not configuration.sessionContext then return invalid
             m.registry.flush()
             return m.context
+        end function
+
+        function isNewInstall() as boolean
+            return m.newInstall
         end function
 
     end class

--- a/src/source/Snowplow/Internal/Configuration.bs
+++ b/src/source/Snowplow/Internal/Configuration.bs
@@ -15,6 +15,7 @@ namespace Snowplow.Internal
     class Configuration
         trackerNamespace as string
         sessionLifetimeSeconds as integer
+        trackInstall = false
 
         ' network
         collector as string
@@ -41,6 +42,7 @@ namespace Snowplow.Internal
         sub new(config)
             m.trackerNamespace = config.namespace ?? Snowplow.Internal.TrackerConstants.DEFAULT_NAMESPACE
             m.sessionLifetimeSeconds = config.sessionLifetimeSeconds ?? Snowplow.Internal.TrackerConstants.DEFAULT_SESSION_LIFETIME_SECONDS
+            m.trackInstall = config.trackInstall ?? false
 
             if config.network <> invalid
                 m.collector = config.network.collector

--- a/src/source/Snowplow/Internal/Emitter.bs
+++ b/src/source/Snowplow/Internal/Emitter.bs
@@ -15,10 +15,12 @@ namespace Snowplow.Internal
     class Emitter
         configuration as Object
         networkConnection as Object
+        cookies as dynamic
 
         sub new(configuration as Object, networkConnection as Object)
             m.configuration = configuration
             m.networkConnection = networkConnection
+            m.cookies = invalid
             m.log = new log.Logger("Snowplow")
         end sub
 
@@ -26,13 +28,17 @@ namespace Snowplow.Internal
             url = m.createUrl()
             if m.configuration.method = "GET"
                 params = event.preparePayloadToSend()
-                success = m.networkConnection.getRequest(url, params, m.getRetryCount(), m.configuration.serverAnonymous)
+                response = m.networkConnection.getRequest(url, params, m.getRetryCount(), m.configuration.serverAnonymous, m.cookies)
             else
                 data = event.prepareDataToSend()
-                success = m.networkConnection.postRequest(url, data, m.getRetryCount(), m.configuration.serverAnonymous)
+                response = m.networkConnection.postRequest(url, data, m.getRetryCount(), m.configuration.serverAnonymous, m.cookies)
             end if
 
-            if not success
+            if response.cookies <> invalid and response.cookies.Count() = 1
+                m.cookies = response.cookies
+            end if
+
+            if not response.ok
                 m.log.error("[emitter] Failed to send event to Snowplow collector")
             end if
         end sub

--- a/src/source/Snowplow/Internal/MediaAdBreakContext.bs
+++ b/src/source/Snowplow/Internal/MediaAdBreakContext.bs
@@ -27,7 +27,7 @@ namespace Snowplow.Internal
         private MABC_POD_SIZE = "podSize"
 
         ' constants
-        private MAC_SCHEMA_MEDIA_AD_BREAK = "iglu:com.snowplowanalytics.snowplow.media/ad_break/jsonschema/1-0-0"
+        private MABC_SCHEMA_MEDIA_AD_BREAK = "iglu:com.snowplowanalytics.snowplow.media/ad_break/jsonschema/1-0-0"
 
         override sub describe(logger)
             logger.debug(`Ad Break ID ${m.breakId}, Name: ${m.name}, startTime: ${m.startTime}, breakType: ${m.breakType}, podSize: ${m.podSize}`)

--- a/src/source/Snowplow/Internal/MediaTracking.bs
+++ b/src/source/Snowplow/Internal/MediaTracking.bs
@@ -292,9 +292,9 @@ namespace Snowplow.Internal
 
             if eventType = MediaTrackingEvent.ERROR
                 payload.Append({
-                    errorCode: info.errorCode,
-                    errorName: info.errorMsg,
-                    errorDescription: info.errorStr
+                    "errorCode": info.errorCode,
+                    "errorName": info.errorMsg,
+                    "errorDescription": info.errorStr
                 })
             else if eventType = MediaTrackingEvent.PERCENT_PROGRESS
                 payload.Append({ "percentProgress": percentProgress })
@@ -308,8 +308,8 @@ namespace Snowplow.Internal
                 })
             else if eventType = MediaTrackingEvent.QUALITY_CHANGE
                 payload.Append({
-                    previousQuality: m.lastQuality.ToStr(),
-                    newQuality: info.streamingSegment.segBitrateBps.ToStr(),
+                    "previousQuality": m.lastQuality.ToStr(),
+                    "newQuality": info.streamingSegment.segBitrateBps.ToStr(),
                     bitrate: info.streamingSegment.segBitrateBps,
                     automatic: true
                 })

--- a/src/source/Snowplow/Internal/NetworkConnection.bs
+++ b/src/source/Snowplow/Internal/NetworkConnection.bs
@@ -41,28 +41,28 @@ namespace Snowplow.Internal
             m.log = new log.Logger("Snowplow")
         end sub
 
-        function postRequest(url as string, body as dynamic, retryCount as integer, anonymous = false as boolean) as boolean
-            response = m.request("POST", url, {
+        function postRequest(url as string, body as dynamic, retryCount as integer, anonymous = false as boolean, cookies = {} as dynamic) as dynamic
+            return m.request("POST", url, {
                 json: body,
                 retryCount: retryCount,
-                anonymous: anonymous
+                anonymous: anonymous,
+                cookies: cookies
             })
-            return response.ok
         end function
 
-        function getRequest(url as string, params as dynamic, retryCount as integer, anonymous = false as boolean) as boolean
-            response = m.request("GET", url, {
+        function getRequest(url as string, params as dynamic, retryCount as integer, anonymous = false as boolean, cookies = {} as dynamic) as dynamic
+            return m.request("GET", url, {
                 params: params,
                 retryCount: retryCount,
-                anonymous: anonymous
+                anonymous: anonymous,
+                cookies: cookies
             })
-            return response.ok
         end function
 
         private function request(method, url as string, args as object)
             _params = {}
             _headers = {}
-            ' _cookies = invalid
+            _cookies = []
             _json = invalid
             _timeout = 30000
             _retryCount = 0
@@ -85,6 +85,9 @@ namespace Snowplow.Internal
                 if args.verify <> invalid and (type(args.verify) = "String" or type(args.verify) = "roString")
                     _verify = args.verify
                 end if
+                if args.cookies <> invalid and type(args.cookies) = "roArray"
+                    _cookies = args.cookies
+                end if
                 if args.anonymous
                     requestHeaders.addHeader(Snowplow.Internal.TrackerConstants.SERVER_ANON_HEADER, "*")
                 end if
@@ -104,14 +107,19 @@ namespace Snowplow.Internal
             url = requestQueryString.append(url)
             headers = requestHeaders._headers
 
-            response = m.runRequest(method, url, headers, data, _timeout, _retryCount, _verify)
+            response = m.runRequest(method, url, headers, data, _timeout, _retryCount, _verify, _cookies)
             return response
         end function
 
-        private function runRequest(method, url, headers, data, timeout, retryCount, verify)
+        private function runRequest(method, url, headers, data, timeout, retryCount, verify, cookies)
             urlTransfer = rokurequests_RequestsUrlTransfer(true, true, verify)
             urlTransfer.setUrl(url)
             urlTransfer.SetHeaders(headers)
+            urlTransfer.EnableCookies()
+
+            if cookies.Count() > 0
+                urlTransfer.AddCookies(cookies)
+            end if
 
             cancel_and_return = false
 
@@ -196,6 +204,7 @@ namespace Snowplow.Internal
                 rr.text = responseEvent.GetString()
                 rr.headers = responseEvent.GetResponseHeaders()
                 rr.headersArray = responseEvent.GetResponseHeadersArray()
+                rr.cookies = urlTransfer.GetCookies("", "/")
 
                 rr.GetSourceIdentity = responseEvent.GetSourceIdentity()
                 rr.GetFailureReason = responseEvent.GetFailureReason()

--- a/src/source/Snowplow/Internal/Subject.bs
+++ b/src/source/Snowplow/Internal/Subject.bs
@@ -19,12 +19,15 @@ namespace Snowplow.Internal
         deviceInfoContextBuilder as object
         sessionContextBuilder as object
         applicationContextBuilder as object
+        newInstall as boolean
 
         sub new(configuration as object)
             m.configuration = configuration
             m.deviceInfoContextBuilder = new Snowplow.Internal.DeviceInfoContextBuilder()
             m.sessionContextBuilder = new Snowplow.Internal.ClientSessionContextBuilder(configuration)
             m.applicationContextBuilder = new Snowplow.Internal.ApplicationContextBuilder()
+
+            m.newInstall = m.sessionContextBuilder.isNewInstall()
         end sub
 
         sub updateEvent(event as object)

--- a/src/source/Snowplow/Internal/Subject.bs
+++ b/src/source/Snowplow/Internal/Subject.bs
@@ -28,7 +28,7 @@ namespace Snowplow.Internal
         end sub
 
         sub updateEvent(event as object)
-            if event.domainSessionId = invalid then event.domainSessionId = m.getDomainUserId()
+            if event.domainSessionId = invalid then event.domainSessionId = m.getDomainSessionId()
             if event.domainUserId = invalid then event.domainUserId = m.getDomainUserId()
             if event.networkUserId = invalid then event.networkUserId = m.getNetworkUserId()
             if event.appId = invalid then event.appId = m.getAppId()

--- a/src/source/Snowplow/Internal/Tracker.bs
+++ b/src/source/Snowplow/Internal/Tracker.bs
@@ -172,5 +172,15 @@ namespace Snowplow.Internal
             end for
             return invalid
         end function
+
+        sub trackApplicationInstall()
+            if m.subject.newInstall
+                event = new Snowplow.Internal.SelfDescribing({
+                    schema: "iglu:com.snowplowanalytics.mobile/application_install/jsonschema/1-0-0",
+                    data: {}
+                })
+                m.trackEvent(event)
+            end if
+        end sub
     end class
 end namespace

--- a/src/source/Snowplow/Internal/Tracker.bs
+++ b/src/source/Snowplow/Internal/Tracker.bs
@@ -82,6 +82,11 @@ namespace Snowplow.Internal
         sub trackMediaEvent(data, port)
             media = data.media ?? data.video ?? data.audio
 
+            if media = invalid
+                m.log.error("[tracker] trackMediaEvent requires a media node already initialized for media tracking.")
+                return
+            end if
+
             adContext = invalid
             ad = data.ad
             if ad <> invalid
@@ -118,7 +123,10 @@ namespace Snowplow.Internal
                 end if
 
                 m.trackEvent(event)
+                return
             end for
+
+            m.log.error("[tracker] Media tracking not initialized for the trackMediaEvent node.")
         end sub
 
         sub stopTrackingMedia(data, port)

--- a/tests/source/Helpers/MockNetworkConnection.bs
+++ b/tests/source/Helpers/MockNetworkConnection.bs
@@ -5,23 +5,23 @@ class MockNetworkConnection
         m.requests = []
     end sub
 
-    function postRequest(url as string, body as dynamic, retryCount as integer, anonymous = false as boolean) as boolean
+    function postRequest(url as string, body as dynamic, retryCount as integer, anonymous = false as boolean) as dynamic
         m.requests.push({
             method: "POST",
             url: url,
             body: body,
             retryCount: retryCount
         })
-        return true
+        return { ok: true }
     end function
 
-    function getRequest(url as string, params as dynamic, retryCount as integer, anonymous = false as boolean) as boolean
+    function getRequest(url as string, params as dynamic, retryCount as integer, anonymous = false as boolean) as dynamic
         m.requests.push({
             method: "GET",
             url: url,
             params: params,
             retryCount: retryCount
         })
-        return true
+        return { ok: true }
     end function
 end class


### PR DESCRIPTION
Fixes some bugs reported/identified in the v0.3.0 release.

- Fix the top-level `snowplow` interface not dispatching `trackMediaEvent` calls to tracker instances
- Fix an error where specifying `adBreak` for `trackMediaEvent` calls would reference an invalid property when finding its schema
- Fix an error where the `error_event` and `quality_change_event` payloads lower-cased their property names, producing schema-violating events
- Fix an issue where defining your own `domainUserId` would cause it to be used for `domainSessionId`
- Add support for automatically tracking the `application_install` event, similar to the mobile SDKs
- Allow consistent Network User ID values within a tracker's lifetime (it is not persisted like `client_session.userId` but should at least be consistent within a session)